### PR TITLE
Presentations: fix Spotify height + normalize Canva embeds

### DIFF
--- a/.cursor/memory/long-term/embeds-conventions.md
+++ b/.cursor/memory/long-term/embeds-conventions.md
@@ -1,0 +1,8 @@
+## 2025-09-16 14:13:08
+
+Project: gdantas.io
+
+-   Presentations page `pages/presentations.tsx` now normalizes Canva links via `toCanvaEmbed` even if `canvaEmbedUrl` is provided in JSON, ensuring `.../view?embed` is used to avoid CSP issues.
+-   Spotify preview uses responsive heights (`h-64 sm:h-80 md:h-96`) and `h-full` iframe to match other cards, replacing previous fixed `style={{ height: 352 }}`.
+-   When adding new entries in `data/presentations.json`, you can set `contentUrl` to any Canva design link or provide `preview.canvaEmbedUrl`; both get normalized. For Spotify, you can provide `contentUrl` or `preview.spotifyEmbedUrl`; both work.
+-   If Canva still refuses to frame, ensure the design is published with Embed (Share > More > Embed > Generate) and is public/anyone with link.

--- a/pages/presentations.tsx
+++ b/pages/presentations.tsx
@@ -173,7 +173,7 @@ export const getStaticProps: GetStaticProps<PresentationsProps> = async () => {
 			}
 		}
 		if (item.preview.type === 'canva') {
-			const canvaEmbedUrl = item.preview.canvaEmbedUrl || toCanvaEmbed(contentLink);
+			const canvaEmbedUrl = toCanvaEmbed(item.preview.canvaEmbedUrl || contentLink);
 			if (canvaEmbedUrl) {
 				presentations.push({ ...item, preview: { type: 'canva', canvaEmbedUrl } });
 				continue;
@@ -227,9 +227,9 @@ function Preview({ presentation }: { presentation: PresentationItem }) {
 	if (presentation.preview.type === 'spotify') {
 		return (
 			<div className="mt-4 w-full">
-				<div className="w-full" style={{ height: 352 }}>
+				<div className="w-full h-64 sm:h-80 md:h-96">
 					<iframe
-						className="w-full rounded-lg border-2 border-gray-200 dark:border-gray-700"
+						className="w-full h-full rounded-lg border-2 border-gray-200 dark:border-gray-700"
 						src={presentation.preview.spotifyEmbedUrl}
 						title={`${presentation.title} - Spotify embed`}
 						frameBorder={0}


### PR DESCRIPTION
Changes:\n- Spotify preview uses responsive heights to match card () and  iframe.\n- Canva preview URLs normalized via toCanvaEmbed to enforce , mitigating Canva frame-ancestors CSP issues when designs are published for embedding.\n\nNotes:\n- If Canva still refuses to frame, ensure the design is shared with Embed (Share > More > Embed) and set to public/anyone with the link.