### PR TITLE
feat(nav): home link + PostHog guideline em AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,22 @@ export default function Page(props: any) {
 }
 ```
 
+## PostHog — métricas funcionais sempre
+
+Instrumentação PostHog é **first-class** no repo, não afterthought. Cada interação relevante do usuário (clique em talk, projeto, link, CTA, contato, preview de presentation) dispara um `posthog.capture(...)` com props estruturadas. Pageviews automáticos via `_app.tsx`.
+
+### Regras
+
+- **Não remova nem renomeie eventos existentes** sem motivo declarado no PR. Nomes de evento e props formam contrato com dashboards/insights no PostHog — renomear quebra histórico silenciosamente.
+- **Toda nova interação clicável visível pro usuário deve capturar evento**. Padrão de nome: `<noun>_<verb_past>` (ex: `talk_clicked`, `cta_clicked`, `contact_link_clicked`). Props em snake_case com contexto suficiente pra segmentar (título, slug, tipo, etc).
+- **Ao mexer num componente que já tem `posthog.capture`**: confira se o evento ainda dispara depois da sua mudança (não esconda atrás de modal, não troque `onClick` por handler que esquece de chamar).
+- **Não envie PII** em props (email, nome real, telefone). Identificadores públicos (slug, título de talk) ok.
+- Refatorações que mudam estrutura de eventos exigem nota no PR: lista de eventos afetados + impacto em insights existentes.
+
+### Eventos atuais (referência rápida)
+
+`talk_clicked`, `talk_card_clicked`, `presentation_played`, `presentation_src_opened`, `project_clicked`, `writing_post_opened`, `link_clicked`, `cta_clicked`, `contact_link_clicked`.
+
 ## Commit / PR
 
 - Branches: `feat/<nome-kebab>`, `fix/<nome-kebab>`, `chore/<nome-kebab>`.

--- a/components/Operator/Header.tsx
+++ b/components/Operator/Header.tsx
@@ -13,6 +13,7 @@ interface NavLink {
 }
 
 const NAV_LINKS: NavLink[] = [
+	{ labelKey: 'nav.home', href: '/' },
 	{ labelKey: 'nav.about', href: '/about' },
 	{ labelKey: 'nav.career', href: '/timeline' },
 	{ labelKey: 'nav.doctrine', href: '/doctrine' },

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,5 +1,6 @@
 {
 	"nav": {
+		"home": "./home",
 		"about": "./about",
 		"career": "./career",
 		"doctrine": "./doctrine",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -1,5 +1,6 @@
 {
 	"nav": {
+		"home": "./home",
 		"about": "./about",
 		"career": "./career",
 		"doctrine": "./doctrine",


### PR DESCRIPTION
## Summary

- Adiciona `nav.home` como primeiro item do header (desktop + mobile drawer). Único caminho de volta pra `/` era o `tty/0` escondido no logo — agora tem link explícito.
- Documenta no `AGENTS.md` a expectativa de manter métricas PostHog funcionais: contrato de eventos, padrão de nome, sem PII, lista de eventos atuais.

## Why

- **Nav home**: sem item óbvio no menu, estando em `/about`, `/talks`, etc. não dava pra voltar pra home sem clicar no logo `tty/0` (que ninguém adivinha que é clicável).
- **PostHog guideline**: instrumentação é first-class no repo (10+ eventos espalhados). Sem nota explícita no AGENTS.md, futuros refactors podem quebrar dashboards silenciosamente ao renomear/remover eventos.

## Base

PR aberto contra `feat/i18n` (não `main`) porque depende de `locales/*.json` e da versão i18n-aware do `Header.tsx`, que só existem nessa branch.

## Test plan

- [x] `yarn i18n:check` passa
- [x] `yarn type-check` passa
- [ ] Manual: navegar pra `/about`, clicar em `./home` → volta pra `/`
- [ ] Manual: mobile drawer mostra `./home` como primeiro item
- [ ] Manual: `/en/about` → drawer mostra `./home` e leva pra `/en/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)