### PR TITLE
chore(seo): remove twitter handle (no account)

### DIFF
--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -86,11 +86,6 @@ export function useSeoProps(
 				},
 			],
 		},
-		twitter: {
-			cardType: 'summary_large_image',
-			handle: '@_gdantas',
-			site: '@_gdantas',
-		},
 		additionalMetaTags: [
 			{ name: 'keywords', content: copy.keywords.join(', ') },
 			{ name: 'author', content: 'Gabriel Dantas' },

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -35,7 +35,6 @@ Domínio canônico: https://gdantas.com.br · Versão em inglês sob o prefixo `
 - [GitHub](https://github.com/gabriel-dantas98): código, projetos open source e repositórios de talks.
 - [LinkedIn](https://www.linkedin.com/in/gabrieldantasg/): perfil profissional.
 - [Medium](https://medium.com/@_gdantas): blog com artigos técnicos.
-- [X / Twitter](https://twitter.com/_gdantas): @_gdantas.
 - [Talk: RAG com dados do Internal Developer Portal (Platform Days 2025)](https://github.com/gabriel-dantas98/platform-talks-rag-idp): construindo um RAG sobre dados de IDP.
 - [Talk: Assistente de Incidentes com MCPs (DevPR Config 2025)](https://github.com/gabriel-dantas98/devparana-incident-agent-mcps): agente de incidentes usando MCP.
 - [Talk: Backstage + Terraform (DevOpsDays SP 2024)](https://docs.google.com/presentation/d/1y6YO9QQjlpEsgxMAOMtUvVcA0OznyMycgAR0EQYAaI8/edit): integração de Backstage com Terraform.


### PR DESCRIPTION
Remove referência ao Twitter/X (`@_gdantas`), já que não há conta.

- `public/llms.txt`: remove o link de X/Twitter da seção Optional
- `lib/seo.ts`: remove o bloco `twitter{}` do next-seo

Open Graph (og:image) segue funcionando para preview de links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)