### PR TITLE
fix(sitemap): point siteUrl to gdantas.com.br

### DIFF
--- a/next-sitemap.js
+++ b/next-sitemap.js
@@ -1,5 +1,5 @@
 const isProduction = process.env.NODE_ENV === 'production';
-const domain = isProduction ? 'gabriel-dantas98.github.io/gdantas.io' : 'localhost:3000';
+const domain = isProduction ? 'gdantas.com.br' : 'localhost:3000';
 const protocol = isProduction ? 'https' : 'http';
 
 /**


### PR DESCRIPTION
Aponta o `next-sitemap` para o domínio canônico real `gdantas.com.br` (GitHub Pages custom domain), substituindo a URL legada `gabriel-dantas98.github.io/gdantas.io`.

Afeta `sitemap.xml` e `robots.txt` gerados no `postbuild`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)