### PR TITLE
fix(sitemap): generate sitemap.xml in Pages deploy (gdantas.com.br)

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -68,6 +68,10 @@ jobs:
         run: ${{ steps.detect-package-manager.outputs.runner }} next build
       - name: Static HTML export with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next export
+      - name: Generate sitemap.xml and robots.txt
+        run: npx next-sitemap --config next-sitemap.js
+        env:
+          NODE_ENV: production
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/next-sitemap.js
+++ b/next-sitemap.js
@@ -6,13 +6,9 @@ const protocol = isProduction ? 'https' : 'http';
  * @type {import('next-sitemap').IConfig}
  */
 module.exports = {
-	exclude: ['/server-sitemap.xml'],
+	// Static export already emitted ./out before next-sitemap runs,
+	// so write the generated sitemap/robots into the export dir.
+	outDir: './out',
 	generateRobotsTxt: true,
-	robotsTxtOptions: {
-		additionalSitemaps: [
-			`${protocol}://${domain}/sitemap.xml`,
-			`${protocol}://${domain}/server-sitemap.xml`,
-		],
-	},
 	siteUrl: `${protocol}://${domain}`,
 };


### PR DESCRIPTION
## Problema

`https://gdantas.com.br/sitemap.xml` retornava **404**: o workflow do GitHub Pages roda `next build` + `next export` e nunca gerava o sitemap (o `postbuild`/`next-sitemap` jamais executava nesse fluxo).

## Correção

- **`.github/workflows/nextjs.yml`**: novo step `next-sitemap` após o export, com `NODE_ENV=production` (pra pegar o domínio `gdantas.com.br`), escrevendo no `./out` antes do upload.
- **`next-sitemap.js`**: `outDir: './out'`; `siteUrl` → `gdantas.com.br`; removida a referência morta a `server-sitemap.xml`.

## Verificação local

`out/sitemap.xml`, `out/sitemap-0.xml` e `out/robots.txt` gerados com o domínio `gdantas.com.br` (rotas pt + /en + /go).

🤖 Generated with [Claude Code](https://claude.com/claude-code)