### PR TITLE
fix(projects): guard against null from fetchProjects()

### DIFF
--- a/components/pages/ProjectsPage.tsx
+++ b/components/pages/ProjectsPage.tsx
@@ -41,7 +41,9 @@ export function ProjectsPage({ stringifiedProjects, locale = 'pt' }: ProjectProp
 
 function ProjectsPageInner({ stringifiedProjects }: { stringifiedProjects: string }) {
 	const t = useT();
-	const projects = JSON.parse(stringifiedProjects) as Project[];
+	// Coalesce to [] in case getStaticProps ever serialized a null
+	// (e.g. GitHub API failure upstream) — never crash the prerender.
+	const projects = (JSON.parse(stringifiedProjects) as Project[] | null) ?? [];
 	const ref = useReveal({ stagger: 0.04, y: 16 });
 	return (
 		<OperatorPage

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -12,7 +12,7 @@ import type { GitHubRepos, Project, ProjectPost } from '~/types';
  *
  * @TODO Switch to v3 API using GraphQL to save over-fetching
  */
-export async function fetchProjects(): Promise<Array<Project> | null> {
+export async function fetchProjects(): Promise<Array<Project>> {
 	const response = await fetch('https://api.github.com/users/gabriel-dantas98/repos', {
 		headers: {
 			...(process.env.GITHUB_PAT && {
@@ -21,9 +21,9 @@ export async function fetchProjects(): Promise<Array<Project> | null> {
 		},
 	});
 	if (response.status !== 200) {
-		const json = (await response.json()) as {
-			documentation_url: string;
-			message: string;
+		const json = (await response.json().catch(() => ({}))) as {
+			documentation_url?: string;
+			message?: string;
 		};
 
 		console.error({ error: json });
@@ -31,7 +31,9 @@ export async function fetchProjects(): Promise<Array<Project> | null> {
 			error: json,
 		});
 
-		return null;
+		// Return an empty list instead of null so the page can still
+		// prerender when GitHub rate-limits unauthenticated CI runners.
+		return [];
 	}
 
 	const json = (await response.json()) as GitHubRepos;


### PR DESCRIPTION
## Problema

O deploy da \`main\` quebrou com:

\`\`\`
TypeError: Cannot read properties of null (reading 'map')
Error occurred prerendering page "/projects"
Error occurred prerendering page "/en/projects"
\`\`\`

Causa: \`fetchProjects()\` retorna \`null\` quando a GitHub API responde não-200. No CI o runner é anônimo (sem \`GITHUB_PAT\`), então em algum deploy bate rate limit, \`JSON.parse("null").map()\` quebra o prerender, e o site inteiro não publica.

## Correção

- **\`lib/projects.ts\`**: retorna \`[]\` no fallback (em vez de \`null\`). Logs do upstream continuam.
- **\`ProjectsPage.tsx\`**: \`?? []\` de segurança no parse, pra nunca crashar prerender de novo.

## Nota

O hook sugeriu migração pro App Router — fora de escopo (projeto é Pages Router em todas as ~10 páginas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)