### PR TITLE
fix(boot): show spinner during typing phase too

### DIFF
--- a/components/Boot/BootSplash.tsx
+++ b/components/Boot/BootSplash.tsx
@@ -175,7 +175,7 @@ export function BootSplash() {
 						justifyContent: 'center',
 					}}
 				>
-					{phase === 'checking' ? <BigSpinner color={OP.amber} /> : status.code}
+					{phase === 'verdict' ? status.code : <BigSpinner color={OP.amber} />}
 				</div>
 				<div style={{ fontSize: 'clamp(22px, 2.6vw, 32px)', color: OP.dim }}>
 					{t('boot.question')}


### PR DESCRIPTION
Follow-up to #27. Verifiquei em produção e ainda aparecia o "—" gigante durante o typewriter (\`status.code\` retorna "—" quando verdict é null + sem erro).

Troquei a condição: o code grande só renderiza quando \`phase === 'verdict'\`. Spinner toma o lugar durante typing E checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)