### PR TITLE
[codex] fix sitemap indexability for Search Console

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Static HTML export
         run: yarn next export
 
+      - name: Sitemap indexability
+        run: yarn sitemap:check
+
       - name: Upload static export
         uses: actions/upload-artifact@v4
         with:

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router';
 
 import type { ComponentProps } from 'react';
 
-import { detectLocaleFromPath } from './i18n';
+import { detectLocaleFromPath, stripLocale, withLocale } from './i18n';
 
 const SITE_URL = 'https://gdantas.com.br';
 const SITE_NAME = 'gdantas';
@@ -62,8 +62,13 @@ export function useSeoProps(
 	const router = useRouter();
 	const locale = detectLocaleFromPath(router.asPath);
 	const copy = COPY[locale];
+	const path = router.asPath.split(/[?#]/)[0] || '/';
+	const canonicalPath = path === '/' ? '' : path;
+	const alternatePath = stripLocale(path);
+	const ptPath = alternatePath === '/' ? '' : alternatePath;
+	const enPath = withLocale(alternatePath, 'en');
 
-	const canonical = `${SITE_URL}${router.asPath === '/' ? '' : router.asPath}`;
+	const canonical = `${SITE_URL}${canonicalPath}`;
 
 	return {
 		title: copy.title,
@@ -86,6 +91,11 @@ export function useSeoProps(
 				},
 			],
 		},
+		languageAlternates: [
+			{ hrefLang: 'pt-BR', href: `${SITE_URL}${ptPath}` },
+			{ hrefLang: 'en', href: `${SITE_URL}${enPath}` },
+			{ hrefLang: 'x-default', href: `${SITE_URL}${ptPath}` },
+		],
 		additionalMetaTags: [
 			{ name: 'keywords', content: copy.keywords.join(', ') },
 			{ name: 'author', content: 'Gabriel Dantas' },

--- a/next-sitemap.js
+++ b/next-sitemap.js
@@ -11,4 +11,10 @@ module.exports = {
 	outDir: './out',
 	generateRobotsTxt: true,
 	siteUrl: `${protocol}://${domain}`,
+	exclude: [
+		// Redirect-only shortcut targets intentionally emit noindex.
+		'/go/*',
+		// Utility error page should not compete with real content in search.
+		'/error',
+	],
 };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "type-check": "tsc",
     "format": "prettier --write \"**/*.{css,js,json,jsx,ts,tsx,vue}\"",
     "i18n:check": "tsx scripts/i18n-check.ts",
+    "sitemap:check": "NODE_ENV=production next-sitemap --config next-sitemap.js && tsx scripts/seo-indexing-check.ts",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
     "e2e:install": "playwright install --with-deps chromium"

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -9,7 +9,8 @@ export default function NotFoundPage() {
 		<OperatorPage
 			title="gdantas ─ 404 not found"
 			description="Página não encontrada."
-			active="/">
+			active="/"
+			noIndex>
 			<div
 				ref={ref}
 				style={{

--- a/pages/error.tsx
+++ b/pages/error.tsx
@@ -14,7 +14,8 @@ export default function ErrorPage() {
 		<OperatorPage
 			title={`gdantas ─ ${code}`}
 			description="Algo deu errado do nosso lado."
-			active="/">
+			active="/"
+			noIndex>
 			<div
 				ref={ref}
 				style={{

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -40,5 +40,13 @@ echo "📤 Generating static HTML export..."
 $RUNNER next export
 
 echo ""
+echo "🔎 Checking generated sitemap indexability..."
+if [ "$MANAGER" = "yarn" ]; then
+	yarn sitemap:check
+else
+	npm run sitemap:check
+fi
+
+echo ""
 echo "✅ Build validation completed successfully!"
 echo "📁 Static files are available in ./out"

--- a/scripts/seo-indexing-check.ts
+++ b/scripts/seo-indexing-check.ts
@@ -1,0 +1,46 @@
+/* eslint-disable no-console */
+// Checks that the generated sitemap only advertises indexable public pages.
+// Run after `next export` + `next-sitemap`.
+
+import fs from 'fs';
+import path from 'path';
+
+const SITE_URL = 'https://gdantas.com.br';
+
+function readUrls(filePath: string): string[] {
+	const xml = fs.readFileSync(filePath, 'utf8');
+	return Array.from(xml.matchAll(/<loc>([^<]+)<\/loc>/g), (match) => match[1]);
+}
+
+function main(): void {
+	const outDir = path.join(process.cwd(), 'out');
+	const sitemapIndex = path.join(outDir, 'sitemap.xml');
+	const childSitemaps = readUrls(sitemapIndex)
+		.map((url) => path.join(outDir, path.basename(url)))
+		.filter((filePath) => fs.existsSync(filePath));
+
+	if (childSitemaps.length === 0) {
+		console.error('[seo-indexing-check] FAILED - no generated child sitemap found');
+		process.exit(1);
+	}
+
+	const urls = childSitemaps.flatMap(readUrls);
+	const badUrls = urls.filter((url) => {
+		if (!url.startsWith(SITE_URL)) return true;
+		if (url.startsWith(`${SITE_URL}/go/`)) return true;
+		if (url === `${SITE_URL}/error`) return true;
+		return false;
+	});
+
+	if (badUrls.length > 0) {
+		console.error('[seo-indexing-check] FAILED - sitemap contains non-indexable URLs:');
+		for (const url of badUrls) {
+			console.error(`  - ${url}`);
+		}
+		process.exit(1);
+	}
+
+	console.log(`[seo-indexing-check] OK - ${urls.length} indexable URL(s) in sitemap`);
+}
+
+main();


### PR DESCRIPTION
## O que mudou

- Remove `/go/*` e `/error` do sitemap gerado.
- Marca `/404` e `/error` como `noindex` no layout Operator.
- Adiciona `hreflang` PT/EN no helper de SEO usado pela home/layout legado.
- Adiciona `yarn sitemap:check` e roda esse gate no CI e no `scripts/ci.sh`.

## Por que

O export do Google Search Console mostrava URLs não indexadas por redirect/noindex. A causa mais direta era o sitemap anunciando atalhos `/go/<slug>` que intencionalmente fazem meta-refresh e emitem `noindex,nofollow`, além da página utilitária `/error` estar no sitemap.

## Como validei

- `yarn type-check`
- `yarn i18n:check`
- `yarn lint`
- `yarn build`
- `yarn next export`
- `yarn sitemap:check`

O check final gerou `https://gdantas.com.br/sitemap.xml` e confirmou `25` URLs indexáveis, sem `/go/*` nem `/error`.