### PR TITLE
feat(talks): add CNCF Campinas - Developer Portal como HUB de MCPs

### DIFF
--- a/components/Operator/PreviewModal.tsx
+++ b/components/Operator/PreviewModal.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 
 import { OP } from './tokens';
 import type { NormalizedPreview } from '~/lib/preview';
+import { useT } from '~/lib/i18n';
 
 interface PreviewModalProps {
 	open: boolean;
@@ -14,7 +15,7 @@ interface PreviewModalProps {
 	href: string;
 }
 
-// Modal de preview: iframe do material + CTA "Conferir ↗". Portal pra body
+// Modal de preview: iframe do material + CTA "conferir ↗". Portal pra body
 // pra escapar de containing blocks (mesmo motivo do MobileMenuDrawer).
 // Fecha em backdrop click / ESC / close button.
 export function PreviewModal({
@@ -26,6 +27,7 @@ export function PreviewModal({
 	preview,
 	href,
 }: PreviewModalProps) {
+	const t = useT();
 	const [mounted, setMounted] = useState(false);
 
 	useEffect(() => {
@@ -129,7 +131,7 @@ export function PreviewModal({
 					<button
 						type="button"
 						onClick={onClose}
-						aria-label="Fechar"
+						aria-label={t('common.close')}
 						style={{
 							background: 'transparent',
 							border: `1px solid ${OP.rule2}`,
@@ -184,8 +186,7 @@ export function PreviewModal({
 								fontSize: 14,
 								color: OP.dim,
 							}}>
-							Preview indisponível pra esse formato — clica em &ldquo;Conferir&rdquo;
-							pra abrir direto na fonte.
+							{t('common.previewUnavailable')}
 						</div>
 					)}
 				</div>
@@ -219,7 +220,7 @@ export function PreviewModal({
 							border: `1px solid ${OP.amber}`,
 							fontWeight: 500,
 						}}>
-						conferir ↗
+						{t('common.confer')}
 					</a>
 				</footer>
 			</div>

--- a/components/pages/PresentationsPage.tsx
+++ b/components/pages/PresentationsPage.tsx
@@ -6,8 +6,15 @@ import { OP, Sec, Prompt, OperatorPage, useReveal } from '~/components/Operator'
 import { Elements as BlogElements } from '~/components/Blog/Styles';
 import type { PresentationItem, PresentationsProps } from '~/lib/presentations-static-props';
 import { I18nProvider, useT } from '~/lib/i18n';
+import { resolveTalkCopy } from '~/lib/talk-copy';
 
-function TalkPreview({ presentation }: { presentation: PresentationItem }) {
+function TalkPreview({
+	presentation,
+	title,
+}: {
+	presentation: PresentationItem;
+	title: string;
+}) {
 	if (!presentation.preview) return null;
 	const frame: React.CSSProperties = {
 		width: '100%',
@@ -50,7 +57,7 @@ function TalkPreview({ presentation }: { presentation: PresentationItem }) {
 					<iframe
 						style={frame}
 						src={presentation.preview.slidesEmbedUrl}
-						title={presentation.title}
+						title={title}
 						allowFullScreen
 						referrerPolicy="strict-origin-when-cross-origin"
 						loading="lazy"
@@ -64,7 +71,7 @@ function TalkPreview({ presentation }: { presentation: PresentationItem }) {
 					<iframe
 						style={frame}
 						src={`https://www.youtube-nocookie.com/embed/${presentation.preview.youtubeId}`}
-						title={presentation.title}
+						title={title}
 						allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
 						allowFullScreen
 						referrerPolicy="strict-origin-when-cross-origin"
@@ -79,7 +86,7 @@ function TalkPreview({ presentation }: { presentation: PresentationItem }) {
 					<iframe
 						style={frame}
 						src={presentation.preview.spotifyEmbedUrl}
-						title={`${presentation.title} - Spotify`}
+						title={`${title} - Spotify`}
 						allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
 						allowFullScreen
 						loading="lazy"
@@ -93,7 +100,7 @@ function TalkPreview({ presentation }: { presentation: PresentationItem }) {
 					<iframe
 						style={frame}
 						src={presentation.preview.canvaEmbedUrl}
-						title={presentation.title}
+						title={title}
 						allowFullScreen
 						allow="clipboard-write"
 						referrerPolicy="strict-origin-when-cross-origin"
@@ -108,7 +115,7 @@ function TalkPreview({ presentation }: { presentation: PresentationItem }) {
 					<iframe
 						style={frame}
 						src={presentation.preview.pdfUrl}
-						title={presentation.title}
+						title={title}
 						allowFullScreen
 						referrerPolicy="strict-origin-when-cross-origin"
 						loading="lazy"
@@ -168,6 +175,10 @@ function PresentationsPageInner({ presentations }: { presentations: Presentation
 					}}>
 					{presentations.map((p, i) => {
 						const contentLink = p.contentUrl || p.url;
+						const copy = resolveTalkCopy(t, p.slug, {
+							title: p.title,
+							description: p.description,
+						});
 						return (
 							<article
 								key={`${p.title}-${i}`}
@@ -205,7 +216,7 @@ function PresentationsPageInner({ presentations }: { presentations: Presentation
 												fontWeight: 500,
 												lineHeight: 1.35,
 											}}>
-											{p.title}
+											{copy.title}
 										</h3>
 										<p
 											style={{
@@ -216,7 +227,7 @@ function PresentationsPageInner({ presentations }: { presentations: Presentation
 												lineHeight: 1.55,
 												maxWidth: 720,
 											}}>
-											{p.description}
+											{copy.description}
 										</p>
 									</div>
 									<div style={{ display: 'flex', gap: 10, flexShrink: 0 }}>
@@ -225,7 +236,12 @@ function PresentationsPageInner({ presentations }: { presentations: Presentation
 												href={contentLink}
 												target="_blank"
 												rel="noreferrer noopener"
-												onClick={() => posthog.capture('presentation_played', { title: p.title, preview_type: p.preview?.type })}
+												onClick={() =>
+													posthog.capture('presentation_played', {
+														title: copy.title,
+														preview_type: p.preview?.type,
+													})
+												}
 												style={{
 													fontFamily: OP.font,
 													fontSize: 11,
@@ -243,7 +259,11 @@ function PresentationsPageInner({ presentations }: { presentations: Presentation
 												href={p.githubUrl}
 												target="_blank"
 												rel="noreferrer noopener"
-												onClick={() => posthog.capture('presentation_src_opened', { title: p.title })}
+												onClick={() =>
+													posthog.capture('presentation_src_opened', {
+														title: copy.title,
+													})
+												}
 												style={{
 													fontFamily: OP.font,
 													fontSize: 11,
@@ -258,7 +278,7 @@ function PresentationsPageInner({ presentations }: { presentations: Presentation
 										)}
 									</div>
 								</header>
-								<TalkPreview presentation={p} />
+								<TalkPreview presentation={p} title={copy.title} />
 							</article>
 						);
 					})}

--- a/components/pages/TalksPage.tsx
+++ b/components/pages/TalksPage.tsx
@@ -14,8 +14,10 @@ import {
 import { derivePreview, type NormalizedPreview, type RawPreview } from '~/lib/preview';
 import presentationsData from '~/data/presentations.json';
 import { I18nProvider, useT } from '~/lib/i18n';
+import { resolveTalkCopy } from '~/lib/talk-copy';
 
 interface RawPresentation {
+	slug?: string;
 	title: string;
 	icon: string;
 	color: string;
@@ -29,6 +31,7 @@ interface RawPresentation {
 }
 
 interface TalkItem {
+	slug?: string;
 	title: string;
 	icon: string;
 	description: string;
@@ -70,6 +73,7 @@ export const getStaticProps: GetStaticProps<TalksProps> = async () => {
 			kind: inferKind(p),
 			preview: derivePreview(p),
 		};
+		if (p.slug) item.slug = p.slug;
 		if (p.date) item.date = p.date;
 		if (p.location) item.location = p.location;
 		return item;
@@ -106,6 +110,12 @@ function TalksPageInner({ talks }: { talks: TalkItem[] }) {
 	const activeMeta = active
 		? [active.date, active.location].filter(Boolean).join(' · ')
 		: '';
+	const activeCopy = active
+		? resolveTalkCopy(t, active.slug, {
+				title: active.title,
+				description: active.description,
+			})
+		: null;
 
 	return (
 		<OperatorPage
@@ -130,13 +140,20 @@ function TalksPageInner({ talks }: { talks: TalkItem[] }) {
 					{talks.map((tk, i) => {
 						const k = kindTag(tk.kind);
 						const meta = [tk.date, tk.location].filter(Boolean).join(' · ');
+						const copy = resolveTalkCopy(t, tk.slug, {
+							title: tk.title,
+							description: tk.description,
+						});
 						return (
 							<button
 								key={`${tk.url}-${i}`}
 								type="button"
 								onClick={() => {
 									setActiveIdx(i);
-									posthog.capture('talk_clicked', { talk_title: tk.title, talk_type: k.tag });
+									posthog.capture('talk_clicked', {
+										talk_title: copy.title,
+										talk_type: k.tag,
+									});
 								}}
 								className="op-talk-card"
 								style={{
@@ -193,7 +210,7 @@ function TalksPageInner({ talks }: { talks: TalkItem[] }) {
 										marginTop: 14,
 										lineHeight: 1.4,
 									}}>
-									{tk.title}
+									{copy.title}
 								</div>
 								<div
 									style={{
@@ -203,7 +220,7 @@ function TalksPageInner({ talks }: { talks: TalkItem[] }) {
 										marginTop: 10,
 										lineHeight: 1.5,
 									}}>
-									{tk.description}
+									{copy.description}
 								</div>
 							</button>
 						);
@@ -226,11 +243,11 @@ function TalksPageInner({ talks }: { talks: TalkItem[] }) {
 				</div>
 			</div>
 
-			{active && activeKind && (
+			{active && activeKind && activeCopy && (
 				<PreviewModal
 					open
 					onClose={() => setActiveIdx(null)}
-					title={active.title}
+					title={activeCopy.title}
 					tag={{ label: activeKind.tag, color: activeKind.color }}
 					meta={activeMeta || undefined}
 					preview={active.preview}

--- a/data/presentations.json
+++ b/data/presentations.json
@@ -4,7 +4,7 @@
 		"title": "CNCF Campinas - Transformando seu Developer Portal em um HUB de MCP's",
 		"icon": "feather:book",
 		"color": "#ff7a45",
-		"description": "Slides da apresentação que fiz no CNCF Campinas sobre como transformamos o Backstage em um hub de MCPs: Actions Registry, OAuth e os limites atuais dessa camada de IA no Developer Portal.",
+		"description": "Slides da apresentação que fiz no CNCF Campinas sobre como transformamos o Backstage em um hub de MCPs: Actions Registry, OAuth, os limites atuais dessa camada de IA no Developer Portal e o caminho até um AI Marketplace de MCPs, Skills, Subagents e Rules.",
 		"contentUrl": "https://docs.google.com/presentation/d/1aUIx47YCVrsTAOFaK25rTr6QvkCSscPjZQ1L6HMLXAo/edit?usp=sharing",
 		"date": "2026-07-30",
 		"location": "Campinas, SP",

--- a/data/presentations.json
+++ b/data/presentations.json
@@ -1,5 +1,19 @@
 [
 	{
+		"slug": "idp-hub-mcps",
+		"title": "CNCF Campinas - Transformando seu Developer Portal em um HUB de MCP's",
+		"icon": "feather:book",
+		"color": "#ff7a45",
+		"description": "Slides da apresentação que fiz no CNCF Campinas sobre como transformamos o Backstage em um hub de MCPs: Actions Registry, OAuth e os limites atuais dessa camada de IA no Developer Portal.",
+		"contentUrl": "https://docs.google.com/presentation/d/1aUIx47YCVrsTAOFaK25rTr6QvkCSscPjZQ1L6HMLXAo/edit?usp=sharing",
+		"date": "2026-07-30",
+		"location": "Campinas, SP",
+		"preview": {
+			"type": "google-slides",
+			"slidesEmbedUrl": "https://docs.google.com/presentation/d/1aUIx47YCVrsTAOFaK25rTr6QvkCSscPjZQ1L6HMLXAo/embed?start=false&loop=false&delayms=3000"
+		}
+	},
+	{
 		"slug": "idp-portals",
 		"title": "DevOps Summit Bluepprint 2025 - ESCALANDO ENGENHARIA COM PORTAIS INTERNOS (IDP's): NAVEGABILIDADE, AUTONOMIA E GOVERNANÇA",
 		"icon": "feather:book",

--- a/lib/talk-copy.ts
+++ b/lib/talk-copy.ts
@@ -1,0 +1,23 @@
+// Resolve title/description de talks via locales, com fallback pro
+// presentations.json. Mesmo padrão do HomePage (`talks.home.<slug>`).
+// Catálogo completo: `talks.items.<slug>.{title,description}`.
+
+export function resolveTalkCopy(
+	t: (key: string) => string,
+	slug: string | undefined,
+	fallback: { title: string; description: string },
+): { title: string; description: string } {
+	if (!slug) return fallback;
+
+	const titleKey = `talks.items.${slug}.title`;
+	const descKey = `talks.items.${slug}.description`;
+	const title = t(titleKey);
+	const description = t(descKey);
+
+	return {
+		title: title.startsWith('talks.items.') ? fallback.title : title,
+		description: description.startsWith('talks.items.')
+			? fallback.description
+			: description,
+	};
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -16,6 +16,7 @@
 		"play": "./play ↗",
 		"preview": "./preview ↗",
 		"confer": "check it out ↗",
+		"previewUnavailable": "Preview unavailable for this format — hit \"Check it out\" to open the source.",
 		"langSwitchLabel": "Switch language"
 	},
 	"hero": {
@@ -100,6 +101,64 @@
 		"footerPrompt": "ls --all | wc -l →",
 		"footerEntries": "entries",
 		"footerLink": "↗ presentations (full list with inline previews)",
+		"items": {
+			"idp-hub-mcps": {
+				"title": "CNCF Campinas - Turning your Developer Portal into an MCP Hub",
+				"description": "Slides from my CNCF Campinas talk on how we turned Backstage into an MCP hub: Actions Registry, OAuth, the current limits of this AI layer in the Developer Portal, and the path to an AI Marketplace of MCPs, Skills, Subagents and Rules."
+			},
+			"idp-portals": {
+				"title": "DevOps Summit Bluepprint 2025 - SCALING ENGINEERING WITH INTERNAL DEVELOPER PORTALS (IDPs): NAVIGABILITY, AUTONOMY AND GOVERNANCE",
+				"description": "Slides from my talk at DevOps Summit Bluepprint 2025 in São Paulo"
+			},
+			"flaky-to-confident": {
+				"title": "QuintoAndar Tech Talks | Building with AI: From Flaky to Confident Releases",
+				"description": "Tech Talk on QuintoAndar's channel about applying GenAI to the release validation loop — using test data for actionable insights, fast root-cause on failures, and immediate fix suggestions."
+			},
+			"cursor-mcp-db": {
+				"title": "Platform Days 2025 - Bringing the database into the IDE with Cursor and MCP: production queries without fear",
+				"description": "Code & slides from my Platform Days 2025 talk in São Paulo"
+			},
+			"incident-mcps": {
+				"title": "DevPR Config 2025 - 10-year special - Building your incident assistant with MCPs",
+				"description": "Code & slides from my DevPR Config 2025 talk in Paraná"
+			},
+			"rag-idp": {
+				"title": "Platform Days 2025 - Building a RAG with data from your Internal Developer Portal",
+				"description": "Slides from my Platform Days SP 2025 talk"
+			},
+			"qa-idp": {
+				"title": "Discover QuintoAndar's IDP - Platform Talks",
+				"description": "Talk on QuintoAndar's Internal Developer Portal at Platform Talks"
+			},
+			"comunidade-backstage": {
+				"title": "Comunidade DevOps - Backstage - building your Internal Developer Portal",
+				"description": "Walkthrough of what you gain with an IDP, plus some of the Backstage experience."
+			},
+			"backstage-tf": {
+				"title": "DevopsDays SP 2024 - Backstage 💙 Terraform",
+				"description": "Slides from my DevopsDays SP 2024 talk"
+			},
+			"tech-leadership-rocks": {
+				"title": "Tech Leadership Rocks - Developer platforms with Victor Fonseca, Gabriel Dantas, Leo Vieira and Caio Queiroz",
+				"description": "Episode with Victor Fonseca, Leo Vieira and Caio Queiroz on building a developer platform with Backstage at QuintoAndar."
+			},
+			"idp-backstage": {
+				"title": "Tech Talk - How we built the developer portal with Backstage.io",
+				"description": "Tech Talk on QuintoAndar's channel covering how we use Backstage.io"
+			},
+			"carreira-sre": {
+				"title": "SRE careers: with Daniel Requena (SRE at iFood), Gabriel Dantas (SRE at QuintoAndar) and Bruno Pereira",
+				"description": "A chat about SRE careers"
+			},
+			"quintocast-backstage": {
+				"title": "QuintoCast - Backstage: Making QuintoAndar engineering navigable",
+				"description": "QuintoAndar tech teams' podcast — the journey of building an engineering portal with Backstage.io"
+			},
+			"jornada-devops": {
+				"title": "DevOps Journey: History and Practice",
+				"description": "Slides from a talk for Senac students on DevOps culture and Platform Engineering"
+			}
+		},
 		"home": {
 			"idp-portals": {
 				"title": "Scaling engineering with Internal Developer Portals: navigability, autonomy and governance",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -16,6 +16,7 @@
 		"play": "./play ↗",
 		"preview": "./preview ↗",
 		"confer": "conferir ↗",
+		"previewUnavailable": "Preview indisponível pra esse formato — clica em \"Conferir\" pra abrir direto na fonte.",
 		"langSwitchLabel": "Mudar idioma"
 	},
 	"hero": {
@@ -100,6 +101,64 @@
 		"footerPrompt": "ls --all | wc -l →",
 		"footerEntries": "entries",
 		"footerLink": "↗ presentations (lista completa com previews inline)",
+		"items": {
+			"idp-hub-mcps": {
+				"title": "CNCF Campinas - Transformando seu Developer Portal em um HUB de MCP's",
+				"description": "Slides da apresentação que fiz no CNCF Campinas sobre como transformamos o Backstage em um hub de MCPs: Actions Registry, OAuth, os limites atuais dessa camada de IA no Developer Portal e o caminho até um AI Marketplace de MCPs, Skills, Subagents e Rules."
+			},
+			"idp-portals": {
+				"title": "DevOps Summit Bluepprint 2025 - ESCALANDO ENGENHARIA COM PORTAIS INTERNOS (IDP's): NAVEGABILIDADE, AUTONOMIA E GOVERNANÇA",
+				"description": "Slides da apresentação que fiz no DevOps Summit Bluepprint 2025 no SP"
+			},
+			"flaky-to-confident": {
+				"title": "QuintoAndar Tech Talks | Building with AI: From Flaky to Confident Releases",
+				"description": "Tech Talk no canal do QuintoAndar sobre como aplicar GenAI ao ciclo de validação de releases, explorando como usar dados gerados por testes para produzir insights acionáveis, identificar rapidamente a causa raiz de falhas e obter sugestões de correção imediatas."
+			},
+			"cursor-mcp-db": {
+				"title": "Platform Days 2025 - Trazendo o banco de dados para dentro da IDE com Cursor e MCP: Consultas em produção sem medo",
+				"description": "Código & Slides da apresentação que fiz no Platform Days 2025 no SP"
+			},
+			"incident-mcps": {
+				"title": "DevPR Config 2025 - especial 10 anos - Criando seu Assistente de Incidentes com MCP's",
+				"description": "Código & Slides da apresentação que fiz no DevPR Config 2025 no Paraná"
+			},
+			"rag-idp": {
+				"title": "Platform Days 2025 - Construindo um RAG com dados do seu Internal Developer Portal",
+				"description": "Slides da apresentação que fiz no Platform Days SP 2025"
+			},
+			"qa-idp": {
+				"title": "Discover QuintoAndar's IDP - Platform Talks",
+				"description": "Apresentação sobre o Internal Developer Portal do QuintoAndar no Platform Talks"
+			},
+			"comunidade-backstage": {
+				"title": "Comunidade DevOps - Backstage - construindo seu Internal Developer Portal",
+				"description": "Conteúdo explicando sobre os ganhos de uma IDP e contando um pouco sobre a experiência com Backstage."
+			},
+			"backstage-tf": {
+				"title": "DevopsDays SP 2024 - Backstage 💙 Terraform",
+				"description": "Slides da apresentação que fiz no DevopsDays SP 2024"
+			},
+			"tech-leadership-rocks": {
+				"title": "Tech Leadership Rocks - Plataforma de desenvolvedores com Victor Fonseca, Gabriel Dantas, Leo Vieira e Caio Queiroz",
+				"description": "Episódio que compartilho junto com o Victor Fonseca, Leo Vieira e Caio Queiroz sobre o case de criação de uma plataforma para desenvolvedores com o Backstage no QuintoAndar."
+			},
+			"idp-backstage": {
+				"title": "Tech Talk -  Como desenvolvemos o developer portal usando o Backstage.io",
+				"description": "Tech Talk no canal do QuintoAndar onde apresentamos um pouco sobre o uso do Backstage.io no QuintoAndar"
+			},
+			"carreira-sre": {
+				"title": "Carreira SRE: com Daniel Requena SRE no Ifood, Gabriel Dantas SRE no Quinto Andar e Bruno Pereira",
+				"description": "Um bate-papo sobre Carreira de SRE"
+			},
+			"quintocast-backstage": {
+				"title": "QuintoCast - Backstage: Tornando a Engenharia do QuintoAndar navegável",
+				"description": "O podcast dos times de tecnologia do QuintoAndar. Onde compartilhamos um pouco da jornada de criar um portal para nossa engenharia usando Backstage.io"
+			},
+			"jornada-devops": {
+				"title": "Jornada DevOps: História e Prática",
+				"description": "Slides da apresentação que fiz para alunos do Senac, sobre Cultura DevOps e Engenharia de Plataforma"
+			}
+		},
 		"home": {
 			"idp-portals": {
 				"title": "Escalando engenharia com Internal Developer Portals: navegabilidade, autonomia e governança",


### PR DESCRIPTION
## Summary
- Adiciona a talk do CNCF Campinas (jul/2026) em `data/presentations.json`: "Transformando seu Developer Portal em um HUB de MCP's"
- Embed do Google Slides como preview (`type: google-slides`), mesmo padrão das demais talks

## Test plan
- [x] `data/presentations.json` validado como JSON
- [x] `yarn tsc --noEmit` sem erros
- [x] `yarn dev` local: `/talks` retorna 200, card aparece no topo da lista com data/local/descrição corretos
- [x] Clique em `./preview` abre o modal e renderiza o slide 1 real via iframe do Google Slides (não é mock estático)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BACCyiCZDH9NcKXMEVDL13